### PR TITLE
payment improvements, bugfixes and more comments

### DIFF
--- a/Backend/logic/handlers/accountHandler.php
+++ b/Backend/logic/handlers/accountHandler.php
@@ -87,7 +87,7 @@ elseif ($action === 'changePassword') {
     }
 }
 
-// Zahlungsmethoden anzeigen
+// Zahlungsmethoden in Tabelle anzeigen im "Zahlung" Tab vom Modal in "Mein Konto"
 elseif ($action === 'loadPaymentMethods') {
     requireLogin();
 
@@ -135,7 +135,7 @@ elseif ($action === 'loadPaymentMethods') {
     }
 }
 
-// Zahlungsmethode laden
+// Zahlungsmethode laden --> notwendig zum ausfüllen der Felder beim Bearbeiten der Zahlungsmethode (funktioniert nur mit Passwort)
 elseif ($action === 'getPaymentMethod') {
     requireLogin();
 
@@ -168,7 +168,7 @@ elseif ($action === 'getPaymentMethod') {
     }
 }
 
-// Neue Zahlungsmethode speichern
+// Neue Zahlungsmethode speichern (funktioniert nur mit Passwort)
 elseif ($action === 'addPaymentMethod') {
     requireLogin();
 
@@ -202,7 +202,7 @@ elseif ($action === 'addPaymentMethod') {
     }
 }
 
-// Zahlungsmethode bearbeiten
+// Zahlungsmethode bearbeiten (funktioniert nur mit Passwort)
 elseif ($action === 'updatePaymentMethod') {
     requireLogin();
 
@@ -239,7 +239,7 @@ elseif ($action === 'updatePaymentMethod') {
 
 }
 
-// Zahlungsart löschen
+// Zahlungsart löschen (funktioniert nur mit Passwort)
 elseif ($action === 'deletePaymentMethod') {
     requireLogin();
 

--- a/Backend/logic/handlers/authHandler.php
+++ b/Backend/logic/handlers/authHandler.php
@@ -21,13 +21,14 @@ if ($action === 'login') {
     } else {
         $result = $userModel->getByEmailOrUsername($loginCredentials);
 
-        if (count($result) === 1) {
+        if (count($result) === 1) { // wenn genau 1 User mit den Daten gefunden wurde
             if ($result[0]['is_active'] == 'inactive') {
                 $response['message'] = "Dein Account ist deaktiviert. Bitte kontaktiere den Support.";
             } elseif (password_verify($password, $result[0]['password_hash'])) {
                 $_SESSION["username"] = $result[0]['username'];
                 $_SESSION["role"] = $result[0]['role'];
 
+                // Cookie "stayLoggedIn" wird für 30 Tage gesetzt (60s * 60 * 24 = 86400)
                 if ($stayLoggedIn === "true" || $stayLoggedIn === true) {
                     setcookie("stayLoggedIn", $loginCredentials, [
                         'expires' => time() + (86400 * 30),
@@ -82,6 +83,7 @@ elseif ($action === 'autoLogin') {
             $_SESSION["username"] = $result[0]['username'];
             $_SESSION["role"] = $result[0]['role'];
 
+            // setzt Cookielebenszeit wieder auf 30 Tage
             setcookie("stayLoggedIn", $loginCredentials, [
                 'expires' => time() + (86400 * 30),
                 'path' => '/'

--- a/Backend/logic/handlers/orderHandler.php
+++ b/Backend/logic/handlers/orderHandler.php
@@ -165,30 +165,5 @@ elseif ($action === 'loadOrderItems') {
     }
 }
 
-// ===== Zahlungsmöglichkeiten anzeigen (nur eingeloggt) =====
-elseif ($action === 'getPaymentMethods') {
-    requireLogin();
-
-    try {
-        $username = $_SESSION['username'];
-        $userResult = $userModel->getByEmailOrUsername($username);
-
-        if (count($userResult) !== 1) {
-            throw new Exception("Benutzerdaten konnten nicht geladen werden.");
-        }
-
-        $user = $userResult[0];
-        $userId = $user['id'];
-
-        $sql = "SELECT id, type, details FROM payment_methods WHERE user_id = ?";
-        $methods = $db->select($sql, [$userId]);
-
-        $response['success'] = true;
-        $response['methods'] = $methods;
-    } catch (Exception $e) {
-        $response['message'] = $e->getMessage();
-    }
-}
-
 echo json_encode($response);
 exit;

--- a/Backend/logic/requestHandler.php
+++ b/Backend/logic/requestHandler.php
@@ -65,7 +65,6 @@ switch ($action) {
     case 'placeOrder':
     case 'loadOrders':
     case 'loadOrderItems':
-    case 'getPaymentMethods':
         require './handlers/orderHandler.php';
         break;
 

--- a/Frontend/js/account.js
+++ b/Frontend/js/account.js
@@ -142,7 +142,7 @@ function zeigeUpdateMessage(message, success) {
     .css("color", success ? "green" : "red");
 }
 
-// Zahlungsarten ladem
+// Zahlungsarten laden für Table im Tab "Zahlung" in Modal
 function ladeZahlungsarten() {
   $.post(
     "../../Backend/logic/requestHandler.php",
@@ -165,14 +165,15 @@ function ladeZahlungsarten() {
             zahl === 1 ? "1 Methode hinterlegt" : `${zahl} Methoden hinterlegt`;
           $("#anzeigeZahlung").text(text);
 
-          data.forEach((item) => {
+          data.forEach((item) => { // "Bearbeiten", "Löschen" und "Neue Zahlungsart hinzufügen" bekommen zusätzlich den type button, damit 
+                                   // diese nicht den alert auslösen beim ein- & ausblenden der jeweiligen Formulare
             const $row = $(`
             <tr>
               <td>${item.type}</td>
               <td>${item.details}</td>
               <td>
-                <button class="btn btn-outline-primary btn-sm me-2" onclick="aendereZahlungsart(${item.id})">Bearbeiten</button>
-                <button class="btn btn-outline-danger btn-sm" onclick="loescheZahlungsart(${item.id})">Löschen</button>
+                <button type="button" class="btn btn-outline-primary btn-sm me-2" onclick="ladeAendereZahlungsartForm(${item.id})"">Bearbeiten</button>
+                <button type="button" class="btn btn-outline-danger btn-sm" onclick="loescheZahlungsart(${item.id})">Löschen</button>
               </td>
             </tr>
           `);
@@ -181,7 +182,7 @@ function ladeZahlungsarten() {
         }
 
         const $addButton = $(`
-        <button class="btn btn-success" onclick="zeigeNeueZahlungsartForm()">Neue Zahlungsart hinzufügen</button>
+        <button type="button" class="btn btn-success" onclick="zeigeNeueZahlungsartForm()">Neue Zahlungsart hinzufügen</button>
       `);
         $addContainer.append($addButton);
       } else {
@@ -194,7 +195,7 @@ function ladeZahlungsarten() {
   );
 }
 
-// Neue Zahlungsart anzeigen
+// Blendet Formular ein zum Hinzufügen einer neuen Zahlungsform. Aufgerufen über Button der in Ladezahlungsarten eingefügt wird
 function zeigeNeueZahlungsartForm() {
   $("#neueZahlungsartForm").toggle();
 }
@@ -239,11 +240,11 @@ function speichereNeueZahlungsmethode() {
   );
 }
 
-// Zahlungsart bearbeiten (vorladen)
-let bearbeitePaymentId = null;
-function aendereZahlungsart(paymentId) {
+// Zahlungsart bearbeiten (vorladen des Formulars, speichern in anderer Methode)
+let bearbeitePaymentId = null; // Variable global erstellt, damit die paymentId zwischen den Methoden weitergegeben wird 
+function ladeAendereZahlungsartForm(paymentId) { // 
   const password = $("#zahlungForm input[name='password']").val();
-  bearbeitePaymentId = paymentId;
+  bearbeitePaymentId = paymentId; // Variable geändert
 
   $.post(
     "../../Backend/logic/requestHandler.php",
@@ -253,12 +254,12 @@ function aendereZahlungsart(paymentId) {
       password,
     },
     function (response) {
-      if (response.success && response.data) {
+      if (response.success && response.data) { // Formulare fürs Hinzufügen / Bearbeiten werden umgeschalten
         const daten = response.data[0];
         $("#aendereZahlungsartForm").show();
         $("#neueZahlungsartForm").hide();
 
-        $("#updated_payment_type").val(daten.type);
+        $("#updated_payment_type").val(daten.type); // Füllt Daten aus Response in Felder
         $("#updated_payment_details").val(daten.details);
       } else {
         zeigeUpdateMessage(
@@ -271,7 +272,7 @@ function aendereZahlungsart(paymentId) {
   );
 }
 
-// Bearbeitete Zahlungsart speichern
+// Bearbeitete Zahlungsart speichern mit Feldern aus Zahlungsformular
 function speichereBearbeiteteZahlungsart() {
   const updatedType = $("#updated_payment_type").val();
   const updatedDetails = $("#updated_payment_details").val();
@@ -289,7 +290,7 @@ function speichereBearbeiteteZahlungsart() {
     "../../Backend/logic/requestHandler.php",
     {
       action: "updatePaymentMethod",
-      paymentId: bearbeitePaymentId,
+      paymentId: bearbeitePaymentId, // PaymentId aus globaler Variable übernommen zur Weitergabe
       type: updatedType,
       details: updatedDetails,
       password,
@@ -301,6 +302,7 @@ function speichereBearbeiteteZahlungsart() {
           : "Fehler: " + response.message,
         response.success
       );
+      bearbeitePaymentId = null; // PaymentId als globale Variable wieder auf null gesetzt
       if (response.success) {
         $("#aendereZahlungsartForm").hide();
         bearbeitePaymentId = null;

--- a/Frontend/js/checkout.js
+++ b/Frontend/js/checkout.js
@@ -56,6 +56,7 @@ function ladeCheckoutWarenkorb() {
   );
 }
 
+// füllt Daten ein in das Bestellformular
 function ladeNutzerdaten() {
   $.post(
     "../../Backend/logic/requestHandler.php",
@@ -75,26 +76,27 @@ function ladeNutzerdaten() {
   );
 }
 
+// für <select> Element mit den hinterlegten Zahlungsarten
 function ladeZahlungsarten() {
   $.post(
     "../../Backend/logic/requestHandler.php",
-    { action: "getPaymentMethods" },
+    { action: "loadPaymentMethods" },
     function (response) {
       const $container = $("#payment_methods").empty();
       $container.append('<h2 class="h5">Zahlungsinformationen:</h2>');
 
       if (
         response.success &&
-        Array.isArray(response.methods) &&
-        response.methods.length > 0
+        Array.isArray(response.data) &&
+        response.data.length > 0
       ) {
         const $select = $(
           '<select class="form-select" name="payment_method" id="payment_method" required></select>'
         );
         $select.append('<option value="">Zahlungsmethode wählen</option>');
 
-        response.methods.forEach((method) => {
-          const option = `<option value="${method.id}">${method.type}</option>`;
+        response.data.forEach((method) => {
+          const option = `<option value="${method.id}">${method.type} - ${method.details}</option>`;
           $select.append(option);
         });
 
@@ -173,6 +175,7 @@ $(document).on("click", "#applyCouponBtn", function () {
   );
 });
 
+// Bestellung aufeben
 $("#checkoutForm").on("submit", function (e) {
   e.preventDefault();
   if (!validateCheckoutForm()) return;

--- a/Frontend/js/navbar.js
+++ b/Frontend/js/navbar.js
@@ -22,7 +22,7 @@ function loadNavbar() {
       document.body.insertBefore(navbarContainer, document.body.firstChild);
 
       fixNavbarLinks(prefix);
-      checkAutoLogin().then(() => {
+      checkAutoLogin().then(() => { // Prüfung ob Cookie stayLoggedIn gesetzt wurde
         handleUserSession(prefix);
         initLogout(prefix);
       });
@@ -121,13 +121,13 @@ function getCookieValue(name) {
   return null;
 }
 
-// Automatischer Login über Cookie
-async function checkAutoLogin() {
+// Automatischer Login über Cookie "stayLoggedIn"
+async function checkAutoLogin() { // Methode async um await zu verwenden
   const savedUser = getCookieValue("stayLoggedIn");
   if (!savedUser) return;
 
   try {
-    const response = await $.ajax({
+    const response = await $.ajax({ // await, damit Funktion erst fertig ausgeführt wird, bevor oben der Logout Button gesetzt wird
       url: "http://localhost/Zeitwert/Backend/logic/requestHandler.php",
       type: "POST",
       data: {

--- a/Frontend/js/orders.js
+++ b/Frontend/js/orders.js
@@ -1,3 +1,4 @@
+// Lädt Tabelle für Bestellungen anhand des Users für orderHistory.html
 function loadOrders() {
   $.ajax({
     url: "http://localhost/Zeitwert/Backend/logic/requestHandler.php",
@@ -19,7 +20,7 @@ function loadOrders() {
           return;
         }
 
-        $.each(order, function (orderId, item) {
+        $.each(order, function (orderId, item) { // laden der einzelnen Zeilen
           const $tableRow = $(`
               <tr>
                 <th scope="row">${item.orderId}</th>
@@ -46,6 +47,7 @@ function loadOrders() {
   });
 }
 
+// Bestellitems werden über Modal angezeigt, welches über Button aufgerufen wird
 function loadOrderItems(orderId) {
   $.ajax({
     url: "http://localhost/Zeitwert/Backend/logic/requestHandler.php",

--- a/Frontend/js/search.js
+++ b/Frontend/js/search.js
@@ -9,7 +9,7 @@ function initLiveSearch() {
 function applySearchFilter() {
   const input = $("#searchFilter").val().trim();
 
-  if (input.length === 0) {
+  if (input.length === 0) { // wenn searchFilter leer ist, sollen Produkte normal geladen werden über products.js
     fetchProducts();
     return;
   }


### PR DESCRIPTION
In orderHistory werden nun die Details bei den Zahlungsmethoden (mittels loadPaymentMethods) angezeigt, falls es einen Type mehrmals gibt.

Redundante Methode getPaymentMethods entfernt, da es bereits getPaymentMethod (fürs einfüllen der Felder in der Accountverwaltung) und loadPaymentMethods (für versteckte Details und laden des Tables in der Accountverwaltung) gibt.

Bug gefixt, wo alert ("Bitte zuerst eine neue Zahlungsart hinzufügen oder eine vorhandene bearbeiten.") erschienen ist beim klicken auf,Bearbeiten/Löschen/Neue Zahlungsart hinzufügen.

Kommentare geschrieben und Methoden etwas umbenannt für mehr Übersicht.